### PR TITLE
Add rect predicates and array conversions; fix integer center() overflow

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -2,10 +2,19 @@ use super::*;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign};
 
 macro_rules! impl_simd_rect {
-    ($name:ident, $vec_type:ty, $num_elements:expr, $lo:expr, $hi:expr) => {
+    ($name:ident, $vec_type:ty, $lane_ty:ty, $dim:expr, $lo:expr, $hi:expr) => {
+        #[doc = concat!(
+                    "An axis-aligned bounding box with [`", stringify!($vec_type), "`] corners."
+                )]
+        ///
+        /// `min` and `max` are inclusive corner bounds. Union is the `|`/`|=`
+        /// operator and intersection is `&`/`&=`; both also accept a vector on
+        /// the right-hand side, treated as a degenerate point-rect.
         #[derive(Clone, Copy, Debug, PartialEq)]
         pub struct $name {
+            /// The minimum (inclusive) corner of the box.
             pub min: $vec_type,
+            /// The maximum (inclusive) corner of the box.
             pub max: $vec_type,
         }
 
@@ -16,33 +25,55 @@ macro_rules! impl_simd_rect {
                 $name { min, max }
             }
 
-            /// Returns the minimum bounds of the rect.
-            #[inline]
-            pub fn min(&self) -> $vec_type {
-                self.min
-            }
-
-            /// Returns the maximum bounds of the rect.
-            #[inline]
-            pub fn max(&self) -> $vec_type {
-                self.max
-            }
-
             /// Returns the center point of the rect.
+            ///
+            /// Assumes a well-formed rect (`min <= max` in every component).
+            /// Computed as `min + extent / 2` so that it cannot overflow for
+            /// well-formed integer rects.
             #[inline]
+            #[must_use]
             pub fn center(&self) -> $vec_type {
-                type LaneType = <$vec_type as SimdVector>::LaneType;
-                (self.min + self.max) / <$vec_type>::splat(2 as LaneType)
+                self.min + self.extent() / (2 as $lane_ty)
             }
 
-            /// Returns the extent (size) of the rect.
+            /// Returns the extent (size) of the rect along each axis.
+            ///
+            /// For unsigned rects this wraps if the rect is not well-formed
+            /// (`min > max` in some component).
             #[inline]
+            #[must_use]
             pub fn extent(&self) -> $vec_type {
                 self.max - self.min
             }
 
+            /// Returns `true` if `point` lies within the box (bounds inclusive).
+            #[inline]
+            #[must_use]
+            pub fn contains(&self, point: $vec_type) -> bool {
+                point.elementwise_max(self.min) == point && point.elementwise_min(self.max) == point
+            }
+
+            /// Returns `true` if the two boxes overlap (touching edges count,
+            /// since bounds are inclusive).
+            #[inline]
+            #[must_use]
+            pub fn intersects(&self, other: &Self) -> bool {
+                let lo = self.min.elementwise_max(other.min);
+                let hi = self.max.elementwise_min(other.max);
+                lo.elementwise_min(hi) == lo
+            }
+
+            /// Returns `true` if the box contains no points, i.e. some
+            /// component of `min` exceeds the corresponding component of `max`.
+            #[inline]
+            #[must_use]
+            pub fn is_empty(&self) -> bool {
+                self.min.elementwise_min(self.max) != self.min
+            }
+
             /// Returns the identity element for union operations.
             /// This rect will not affect the result when unioned with any other rects.
+            #[must_use]
             pub fn union_identity() -> Self {
                 $name {
                     min: <$vec_type>::splat($hi),
@@ -52,10 +83,28 @@ macro_rules! impl_simd_rect {
 
             /// Returns the identity element for intersection operations.
             /// This rect will not affect the result when intersected with any other rects.
+            #[must_use]
             pub fn intersection_identity() -> Self {
                 $name {
                     min: <$vec_type>::splat($lo),
                     max: <$vec_type>::splat($hi),
+                }
+            }
+        }
+
+        // Flatten a rect into a `[min_array, max_array]` pair, and back.
+        impl From<$name> for [[$lane_ty; $dim]; 2] {
+            #[inline]
+            fn from(rect: $name) -> Self {
+                [rect.min.into(), rect.max.into()]
+            }
+        }
+        impl From<[[$lane_ty; $dim]; 2]> for $name {
+            #[inline]
+            fn from([min, max]: [[$lane_ty; $dim]; 2]) -> Self {
+                $name {
+                    min: min.into(),
+                    max: max.into(),
                 }
             }
         }
@@ -126,16 +175,29 @@ macro_rules! impl_simd_rect {
     };
 }
 
-impl_simd_rect!(SimdRect2, SimdVec2, 2, f32::NEG_INFINITY, f32::INFINITY);
-impl_simd_rect!(SimdURect2, SimdUVec2, 2, u32::MIN, u32::MAX);
-impl_simd_rect!(SimdIRect2, SimdIVec2, 2, i32::MIN, i32::MAX);
+impl_simd_rect!(
+    SimdRect2,
+    SimdVec2,
+    f32,
+    2,
+    f32::NEG_INFINITY,
+    f32::INFINITY
+);
+impl_simd_rect!(SimdURect2, SimdUVec2, u32, 2, u32::MIN, u32::MAX);
+impl_simd_rect!(SimdIRect2, SimdIVec2, i32, 2, i32::MIN, i32::MAX);
 
-impl_simd_rect!(SimdRect3, SimdVec3, 3, f32::NEG_INFINITY, f32::INFINITY);
-impl_simd_rect!(SimdURect3, SimdUVec3, 3, u32::MIN, u32::MAX);
-impl_simd_rect!(SimdIRect3, SimdIVec3, 3, i32::MIN, i32::MAX);
+impl_simd_rect!(
+    SimdRect3,
+    SimdVec3,
+    f32,
+    3,
+    f32::NEG_INFINITY,
+    f32::INFINITY
+);
+impl_simd_rect!(SimdURect3, SimdUVec3, u32, 3, u32::MIN, u32::MAX);
+impl_simd_rect!(SimdIRect3, SimdIVec3, i32, 3, i32::MIN, i32::MAX);
 
 //--------------------------------------------------------------------------------------------------
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,8 +263,8 @@ mod tests {
                     let max = <$vec_type>::from([vals[2], vals[3]]);
                     let rect = <$rect_type>::new(min, max);
 
-                    assert_vec2_eq(rect.min(), min);
-                    assert_vec2_eq(rect.max(), max);
+                    assert_vec2_eq(rect.min, min);
+                    assert_vec2_eq(rect.max, max);
                 }
 
                 #[test]
@@ -212,8 +274,8 @@ mod tests {
                     let max = <$vec_type>::from([vals[2], vals[3]]);
                     let rect = <$rect_type>::new(min, max);
 
-                    assert_vec2_eq(rect.min(), min);
-                    assert_vec2_eq(rect.max(), max);
+                    assert_vec2_eq(rect.min, min);
+                    assert_vec2_eq(rect.max, max);
                 }
 
                 #[test]
@@ -531,8 +593,8 @@ mod tests {
                     let max = <$vec_type>::from([vals[3], vals[4], vals[5]]);
                     let rect = <$rect_type>::new(min, max);
 
-                    assert_vec3_eq(rect.min(), min);
-                    assert_vec3_eq(rect.max(), max);
+                    assert_vec3_eq(rect.min, min);
+                    assert_vec3_eq(rect.max, max);
                 }
 
                 #[test]
@@ -542,8 +604,8 @@ mod tests {
                     let max = <$vec_type>::from([vals[3], vals[4], vals[5]]);
                     let rect = <$rect_type>::new(min, max);
 
-                    assert_vec3_eq(rect.min(), min);
-                    assert_vec3_eq(rect.max(), max);
+                    assert_vec3_eq(rect.min, min);
+                    assert_vec3_eq(rect.max, max);
                 }
 
                 #[test]
@@ -948,4 +1010,93 @@ mod tests {
         ],
         assert_i32_eq
     );
+}
+
+#[cfg(test)]
+mod rect_api_tests {
+    use super::*;
+
+    #[test]
+    fn test_contains() {
+        let r = SimdRect2::new(SimdVec2::from([0.0, 0.0]), SimdVec2::from([2.0, 3.0]));
+        assert!(r.contains(SimdVec2::from([1.0, 1.0])));
+        assert!(r.contains(SimdVec2::from([0.0, 0.0]))); // bounds are inclusive
+        assert!(r.contains(SimdVec2::from([2.0, 3.0]))); // bounds are inclusive
+        assert!(!r.contains(SimdVec2::from([2.1, 1.0])));
+        assert!(!r.contains(SimdVec2::from([-0.1, 1.0])));
+
+        let r3 = SimdIRect3::new(SimdIVec3::from([0, 0, 0]), SimdIVec3::from([2, 2, 2]));
+        assert!(r3.contains(SimdIVec3::from([1, 1, 1])));
+        assert!(!r3.contains(SimdIVec3::from([1, 1, 3])));
+    }
+
+    #[test]
+    fn test_intersects() {
+        let a = SimdRect2::new(SimdVec2::from([0.0, 0.0]), SimdVec2::from([2.0, 2.0]));
+        let b = SimdRect2::new(SimdVec2::from([1.0, 1.0]), SimdVec2::from([3.0, 3.0]));
+        let c = SimdRect2::new(SimdVec2::from([5.0, 5.0]), SimdVec2::from([6.0, 6.0]));
+        let touching = SimdRect2::new(SimdVec2::from([2.0, 0.0]), SimdVec2::from([3.0, 2.0]));
+        assert!(a.intersects(&b));
+        assert!(b.intersects(&a));
+        assert!(!a.intersects(&c));
+        assert!(a.intersects(&touching)); // touching edges count
+
+        let a3 = SimdURect3::new(SimdUVec3::from([0, 0, 0]), SimdUVec3::from([2, 2, 2]));
+        let b3 = SimdURect3::new(SimdUVec3::from([3, 0, 0]), SimdUVec3::from([4, 2, 2]));
+        assert!(!a3.intersects(&b3));
+    }
+
+    #[test]
+    fn test_is_empty() {
+        assert!(SimdRect2::union_identity().is_empty());
+        assert!(!SimdRect2::intersection_identity().is_empty());
+        assert!(SimdURect3::union_identity().is_empty());
+
+        // A degenerate point-rect still contains one point.
+        let point_rect = SimdRect2::new(SimdVec2::ZERO, SimdVec2::ZERO);
+        assert!(!point_rect.is_empty());
+
+        // Intersection of disjoint rects is empty.
+        let a = SimdRect3::new(SimdVec3::ZERO, SimdVec3::from([1.0, 1.0, 1.0]));
+        let b = SimdRect3::new(
+            SimdVec3::from([2.0, 0.0, 0.0]),
+            SimdVec3::from([3.0, 1.0, 1.0]),
+        );
+        assert!((a & b).is_empty());
+        assert!(!a.intersects(&b));
+    }
+
+    #[test]
+    fn test_array_conversions() {
+        let r = SimdIRect2::from([[0, 1], [4, 5]]);
+        assert_eq!(r.min, SimdIVec2::from([0, 1]));
+        assert_eq!(r.max, SimdIVec2::from([4, 5]));
+        let arr: [[i32; 2]; 2] = r.into();
+        assert_eq!(arr, [[0, 1], [4, 5]]);
+
+        let arr3: [[f32; 3]; 2] = SimdRect3::new(
+            SimdVec3::from([1.0, 2.0, 3.0]),
+            SimdVec3::from([4.0, 5.0, 6.0]),
+        )
+        .into();
+        assert_eq!(arr3, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    }
+
+    #[test]
+    fn test_int_center_no_overflow() {
+        // (min + max) / 2 would overflow here; min + extent / 2 must not.
+        let r = SimdIRect2::new(
+            SimdIVec2::from([i32::MAX - 4, i32::MAX - 8]),
+            SimdIVec2::from([i32::MAX, i32::MAX]),
+        );
+        let center = r.center();
+        assert_eq!(center, SimdIVec2::from([i32::MAX - 2, i32::MAX - 4]));
+
+        let r = SimdURect2::new(
+            SimdUVec2::from([u32::MAX - 4, u32::MAX - 8]),
+            SimdUVec2::from([u32::MAX, u32::MAX]),
+        );
+        let center = r.center();
+        assert_eq!(center, SimdUVec2::from([u32::MAX - 2, u32::MAX - 4]));
+    }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -469,41 +469,26 @@ fn example_collision_detection() {
     let wall_max = SimdVec3::from([2.5, 3.0, 5.0]);
     let wall_aabb = SimdRect3::new(wall_min, wall_max);
 
-    // Test no collision initially
-    let intersection = player_aabb & wall_aabb;
-    let intersection_extent = intersection.extent();
-
-    // No intersection should result in negative extent
-    assert!(
-        intersection_extent[0] < 0.0
-            || intersection_extent[1] < 0.0
-            || intersection_extent[2] < 0.0
-    );
+    // No collision initially: the boxes are disjoint, so their intersection
+    // is empty.
+    assert!(!player_aabb.intersects(&wall_aabb));
+    assert!((player_aabb & wall_aabb).is_empty());
 
     // Move player toward wall
     let player_new_min = SimdVec3::from([1.8, 0.0, -0.5]);
     let player_new_max = SimdVec3::from([2.8, 2.0, 0.5]);
     let player_moved_aabb = SimdRect3::new(player_new_min, player_new_max);
 
-    // Test collision after movement
-    let _collision_intersection = player_moved_aabb & wall_aabb;
-
-    // Based on debug output, AABB intersection with overlap has negative extents
-    // So check for overlap using the standard AABB overlap test
-    let overlaps_x = player_moved_aabb.max()[0] > wall_aabb.min()[0]
-        && player_moved_aabb.min()[0] < wall_aabb.max()[0];
-    let overlaps_y = player_moved_aabb.max()[1] > wall_aabb.min()[1]
-        && player_moved_aabb.min()[1] < wall_aabb.max()[1];
-    let overlaps_z = player_moved_aabb.max()[2] > wall_aabb.min()[2]
-        && player_moved_aabb.min()[2] < wall_aabb.max()[2];
-
-    let has_collision = overlaps_x && overlaps_y && overlaps_z;
-
     // With the moved player AABB, there should be overlap
     assert!(
-        has_collision,
+        player_moved_aabb.intersects(&wall_aabb),
         "Player should collide with wall after movement"
     );
+    let overlap = player_moved_aabb & wall_aabb;
+    assert!(!overlap.is_empty());
+    // The overlapping region is the part of the wall the player has entered.
+    assert!((overlap.min[0] - 2.0).abs() < 1e-6);
+    assert!((overlap.max[0] - 2.5).abs() < 1e-6);
 }
 
 #[test]
@@ -538,21 +523,17 @@ fn example_spatial_partitioning() {
         combined_bounds |= *object;
     }
 
-    // Verify combined bounds contains all objects
+    // Verify combined bounds contains all objects (bounds are inclusive, so
+    // corners that lie exactly on the boundary count as contained).
     for object in &objects {
-        // Check that each object is fully contained in combined bounds
-        assert!(object.min()[0] >= combined_bounds.min()[0] - 1e-6);
-        assert!(object.min()[1] >= combined_bounds.min()[1] - 1e-6);
-        assert!(object.min()[2] >= combined_bounds.min()[2] - 1e-6);
-        assert!(object.max()[0] <= combined_bounds.max()[0] + 1e-6);
-        assert!(object.max()[1] <= combined_bounds.max()[1] + 1e-6);
-        assert!(object.max()[2] <= combined_bounds.max()[2] + 1e-6);
+        assert!(combined_bounds.contains(object.min));
+        assert!(combined_bounds.contains(object.max));
     }
 
     // Test that combined bounds is reasonable
-    assert!(combined_bounds.min()[0] <= -2.0);
-    assert!(combined_bounds.max()[0] >= 3.0);
-    assert!(combined_bounds.max()[1] >= 5.0);
+    assert!(combined_bounds.min[0] <= -2.0);
+    assert!(combined_bounds.max[0] >= 3.0);
+    assert!(combined_bounds.max[1] >= 5.0);
 }
 
 #[test]
@@ -581,26 +562,15 @@ fn example_frustum_culling() {
         SimdVec3::from([12.0, 12.0, 7.0]),
     );
 
-    // Test visibility (we'll use direct overlap tests instead of intersection extents)
-
-    // Use standard AABB overlap test since intersection extent behavior is inverted
-    let visible_overlaps = visible_object.max()[0] > frustum_aabb.min()[0]
-        && visible_object.min()[0] < frustum_aabb.max()[0]
-        && visible_object.max()[1] > frustum_aabb.min()[1]
-        && visible_object.min()[1] < frustum_aabb.max()[1]
-        && visible_object.max()[2] > frustum_aabb.min()[2]
-        && visible_object.min()[2] < frustum_aabb.max()[2];
-
-    let hidden_overlaps = hidden_object.max()[0] > frustum_aabb.min()[0]
-        && hidden_object.min()[0] < frustum_aabb.max()[0]
-        && hidden_object.max()[1] > frustum_aabb.min()[1]
-        && hidden_object.min()[1] < frustum_aabb.max()[1]
-        && hidden_object.max()[2] > frustum_aabb.min()[2]
-        && hidden_object.min()[2] < frustum_aabb.max()[2];
-
-    // Visible object should overlap, hidden should not
-    assert!(visible_overlaps, "Visible object should be in frustum");
-    assert!(!hidden_overlaps, "Hidden object should not be in frustum");
+    // Visible object should overlap the frustum, hidden should not
+    assert!(
+        frustum_aabb.intersects(&visible_object),
+        "Visible object should be in frustum"
+    );
+    assert!(
+        !frustum_aabb.intersects(&hidden_object),
+        "Hidden object should not be in frustum"
+    );
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Stack 4/6** — stacked on #10. Merge bottom-up.

- `contains(point)`, `intersects(&other)`, `is_empty()` — callers previously had to hand-roll the AABB overlap test because empty intersections are non-obvious in the min/max representation; our own integration tests did exactly that (with a "based on debug output, intersection extent behavior is inverted" comment). Those tests now use the predicates.
- `[[lane; N]; 2]` array conversions both ways, matching the vector types (README wishlist item)
- `center()` computed as `min + extent/2` so it cannot overflow for well-formed integer rects — `(min + max) / 2` silently wrapped near the type max (regression test included)
- Removed the `min()`/`max()` accessor methods that duplicated the public `min`/`max` fields
- All public items documented

⚠️ Breaking: `rect.min()`/`rect.max()` calls become `rect.min`/`rect.max` field accesses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXAvrKfpM1mzeggVoHtYz2)_