### PR TITLE
Add prelude with named component indices; document everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This decision further eschews conventions about what is front, up, and right in 
 
 Vectors are column vectors. Matrix multiplication is `Matrix * Vector`.
 
-Matrices are constructed in column-major order, i.e. each argument to `SimdMat3x4::new` is a column. This is consistent with OpenGL and GLM, but not with most textbook math. `SimdMat3x4` is a 3×4 affine transform: three transformed basis-vector columns plus a translation column, with an implicit `[0, 0, 0, 1]` bottom row.
+Matrices are constructed in column-major order, i.e. each argument to `SimdMat3x4::new` is a column. Matrix dimensions are named rows×columns, as in mathematics, HLSL, and Vulkan — so `SimdMat3x4` has 3 rows and 4 columns: three transformed basis-vector columns plus a translation column, with an implicit `[0, 0, 0, 1]` bottom row, mapping homogeneous 4-vectors to 3-vectors. (Beware: GLSL and GLM name matrix types columns-first and would call this same shape `mat4x3`.)
 
 Quaternions are represented as `(s, x, y, z)` where `s` is the scalar part. Think `s + iv`.
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@
 
 A Rust library providing SIMD-accelerated mathematical functions for games, graphics, robotics, and other spatial computing applications.
 
+> [!IMPORTANT]
+> This crate is built on Rust's unstable [`portable_simd`](https://doc.rust-lang.org/std/simd/index.html) feature and requires a **nightly** toolchain. This repository pins a known-good nightly via `rust-toolchain.toml`, so `cargo build` inside the repo just works.
+
 ## Example
 
 ```rust
 // See tests/integration_test.rs test_readme_example() for full runnable code.
 // See tests/integration_test.rs for more examples.
 
-use simd_math::*;
+use simd_math::prelude::*;
 use std::f32::consts::PI;
 
 // Create a 3D vector
@@ -22,6 +25,9 @@ let rotation = SimdUnitQuat::from_axis_angle(SimdVec3::from([0.0, 0.0, 1.0]), PI
 
 // Apply rotation to vector
 let rotated_vector = rotation * vector;
+
+// Components are accessed by index; the prelude provides X/Y/Z/W constants
+assert!((rotated_vector[Y] - 1.0).abs() < 1e-6);
 ```
 
 ## Conventions and Quirks
@@ -30,7 +36,7 @@ let rotated_vector = rotation * vector;
 
 We ensure that our algebraic types are convertible to and from Rust arrays. Use arrays in your APIs for simple, math-library-agnostic interfaces. Cf [Mujoco](https://github.com/google-deepmind/mujoco).
 
-In the same spirit, we do not expose `.x`, `.y`, `.z` fields on vectors or quaternions. Use indexing (`v[0]`, `v[1]`, `v[2]`).
+In the same spirit, we do not expose `.x`, `.y`, `.z` fields on vectors or quaternions. Use indexing: `v[0]`, `v[1]`, `v[2]`, or equivalently `v[X]`, `v[Y]`, `v[Z]` with the named index constants from `simd_math::prelude`.
 
 This decision further eschews conventions about what is front, up, and right in 3D space, which vary between applications. It also makes it easier to use vectors for non-spatial data, e.g. color.
 
@@ -38,14 +44,14 @@ This decision further eschews conventions about what is front, up, and right in 
 
 Vectors are column vectors. Matrix multiplication is `Matrix * Vector`.
 
-Matrices are constructed in column-major order, i.e. each argument to `Mat3::new` is a column.
-This is consistent with OpenGL and GLM, but not with most textbook math.
+Matrices are constructed in column-major order, i.e. each argument to `SimdMat3x4::new` is a column. This is consistent with OpenGL and GLM, but not with most textbook math. `SimdMat3x4` is a 3×4 affine transform: three transformed basis-vector columns plus a translation column, with an implicit `[0, 0, 0, 1]` bottom row.
 
 Quaternions are represented as `(s, x, y, z)` where `s` is the scalar part. Think `s + iv`.
 
 We assume a right-handed coordinate system.
 
-## TODO
+Spherical coordinates are `(azimuth, elevation, radius)` with Y up: azimuth is measured in the XZ plane from +X towards +Z in `[-π, π]`, and elevation is measured towards +Y in `[-π/2, π/2]`.
 
-- [ ] Need easier conversion between scalar types, e.g. `SimdUVec2` from `[u16; 2]` should work.
-- [ ] Need flattening for rects, e.g. `into_array()` methods on all types?
+### Hidden SIMD lanes
+
+3-component vectors are stored in 4-lane registers. The extra lane is an internal detail: it always holds zero, every operation preserves that invariant, and equality, `Debug`, indexing, and reductions all ignore it. Indexing a `SimdVec3` with `v[3]` panics.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,39 @@
 #![feature(portable_simd)]
+#![warn(missing_docs)]
 
-//! A SIMD-accelerated math library for 3D graphics and linear algebra operations.
+//! A SIMD-accelerated math library for games, graphics, robotics, and other
+//! spatial computing applications.
 //!
-//! This library provides high-performance vector, quaternion, matrix, transform, and AABB
-//! operations using Rust's portable SIMD functionality.
-
-mod rect;
-pub use rect::*;
+//! Provides vector ([`SimdVec3`] and friends), quaternion ([`SimdUnitQuat`]),
+//! affine-matrix ([`SimdMat3x4`]), rigid-transform ([`SimdTransform`]), and
+//! axis-aligned bounding box ([`SimdRect3`] and friends) types built on Rust's
+//! portable SIMD.
+//!
+//! # Nightly requirement
+//!
+//! This crate uses the unstable [`portable_simd`] feature and therefore
+//! requires a **nightly** toolchain. This repository pins a known-good nightly
+//! via `rust-toolchain.toml`.
+//!
+//! [`portable_simd`]: https://doc.rust-lang.org/std/simd/index.html
+//!
+//! # Example
+//!
+//! ```
+//! use simd_math::prelude::*;
+//! use std::f32::consts::PI;
+//!
+//! // Create a 3D vector
+//! let vector = SimdVec3::from([1.0, 0.0, 0.0]);
+//!
+//! // Create a rotation quaternion (90 degrees around Z-axis)
+//! let rotation = SimdUnitQuat::from_axis_angle(SimdVec3::from([0.0, 0.0, 1.0]), PI / 2.0);
+//!
+//! // Apply rotation to vector; components are indexed, with named index
+//! // constants available from the prelude.
+//! let rotated = rotation * vector;
+//! assert!((rotated[Y] - 1.0).abs() < 1e-6);
+//! ```
 
 mod mat3x4;
 pub use mat3x4::*;
@@ -14,10 +41,35 @@ pub use mat3x4::*;
 mod quaternion;
 pub use quaternion::*;
 
+mod rect;
+pub use rect::*;
+
 mod transform;
 pub use transform::*;
 
 mod vector;
 pub use vector::*;
+
+pub mod prelude {
+    //! One-stop import: every public type, plus named component indices.
+    //!
+    //! The [`X`]/[`Y`]/[`Z`]/[`W`] constants let you index vector components
+    //! by name instead of by bare integer: `v[X]` instead of `v[0]`.
+
+    pub use crate::{
+        SimdIRect2, SimdIRect3, SimdIVec2, SimdIVec3, SimdIVec4, SimdMat3x4, SimdRect2, SimdRect3,
+        SimdTransform, SimdURect2, SimdURect3, SimdUVec2, SimdUVec3, SimdUVec4, SimdUnitQuat,
+        SimdVec2, SimdVec3, SimdVec4, SimdVector,
+    };
+
+    /// Index of the X component of a vector.
+    pub const X: usize = 0;
+    /// Index of the Y component of a vector.
+    pub const Y: usize = 1;
+    /// Index of the Z component of a vector.
+    pub const Z: usize = 2;
+    /// Index of the W component of a vector.
+    pub const W: usize = 3;
+}
 
 use std::simd::prelude::*;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,7 @@
 //! These tests also serve as comprehensive examples of how to use the simd_math library
 //! for real-world 3D graphics, animation, and spatial computing applications.
 
-use simd_math::*;
+use simd_math::prelude::*;
 use std::f32::consts::PI;
 
 //--------------------------------------------------------------------------------------------------
@@ -487,8 +487,8 @@ fn example_collision_detection() {
     let overlap = player_moved_aabb & wall_aabb;
     assert!(!overlap.is_empty());
     // The overlapping region is the part of the wall the player has entered.
-    assert!((overlap.min[0] - 2.0).abs() < 1e-6);
-    assert!((overlap.max[0] - 2.5).abs() < 1e-6);
+    assert!((overlap.min[X] - 2.0).abs() < 1e-6);
+    assert!((overlap.max[X] - 2.5).abs() < 1e-6);
 }
 
 #[test]
@@ -673,8 +673,6 @@ fn example_camera_projection() {
 
     // Camera parameters
     let camera_position = SimdVec3::ZERO;
-    let fov = PI / 3.0; // 60 degrees
-    let aspect_ratio = 16.0 / 9.0;
 
     for world_point in world_points {
         // Transform to camera space (simplified - just translate)
@@ -682,25 +680,15 @@ fn example_camera_projection() {
 
         // Convert to spherical for angular calculations
         let spherical = camera_space.into_spherical_coords();
-        let azimuth = spherical[0];
-        let elevation = spherical[1];
+        let azimuth = spherical[X];
+        let elevation = spherical[Y];
+        let radius = spherical[Z];
 
-        // Simple angular bounds check (is point in field of view?)
-        let half_fov = fov / 2.0;
-        let half_fov_x = half_fov * aspect_ratio;
-
-        let in_fov = azimuth.abs() < half_fov_x && elevation.abs() < half_fov;
-
-        // Point should have reasonable angular coordinates
-        assert!(azimuth.abs() < PI);
-        assert!(elevation.abs() < PI / 2.0);
-
-        // Close points should be more likely to be in FOV
-        if camera_space[2] < 6.0 {
-            // Don't assert in_fov as it depends on the specific points,
-            // but verify we can compute it
-            let _computed_fov_check = in_fov;
-        }
+        // Angular coordinates must land in their documented ranges, and the
+        // radius must equal the point's distance from the camera.
+        assert!(azimuth.abs() <= PI);
+        assert!(elevation.abs() <= PI / 2.0);
+        assert!((radius - camera_space.norm()).abs() < 1e-5);
     }
 }
 
@@ -972,8 +960,9 @@ fn test_readme_example() {
     // Apply rotation to vector
     let rotated_vector = rotation * vector;
 
-    // Verify the rotation worked correctly (90-degree rotation around Z should turn (1,0,0) into (0,1,0))
-    assert!((rotated_vector[0] - 0.0).abs() < 1e-6);
-    assert!((rotated_vector[1] - 1.0).abs() < 1e-6);
-    assert!((rotated_vector[2] - 0.0).abs() < 1e-6);
+    // Verify the rotation worked correctly (90-degree rotation around Z should turn (1,0,0) into (0,1,0)).
+    // Components are indexed; the prelude's X/Y/Z constants name the indices.
+    assert!((rotated_vector[X] - 0.0).abs() < 1e-6);
+    assert!((rotated_vector[Y] - 1.0).abs() < 1e-6);
+    assert!((rotated_vector[Z] - 0.0).abs() < 1e-6);
 }


### PR DESCRIPTION
**Stack 5/6** — stacked on #11. Merge bottom-up.

New `simd_math::prelude` module: re-exports every public type plus named component-index constants `X = 0`, `Y = 1`, `Z = 2`, `W = 3`, so components read as `v[X]` instead of `v[0]` while keeping the crate's index-not-field access convention.

```rust
use simd_math::prelude::*;

let rotated = rotation * vector;
assert!((rotated[Y] - 1.0).abs() < 1e-6);
```

Also:
- Enables `#[warn(missing_docs)]`; every public item is now documented (the layers below prepared their modules for this)
- Crate-level docs state the nightly/`portable_simd` requirement and include a runnable doctest
- README: nightly requirement callout, prelude example, spherical-coordinate convention (Y-up, azimuth from +X towards +Z), the hidden-lane guarantee, and `SimdMat3x4::new` instead of the nonexistent `Mat3::new`
- Integration tests import the prelude and use named indices where it helps; the camera-projection example asserts documented ranges and the radius round-trip instead of computing an unused FOV check